### PR TITLE
fixes for the Red Hat 6 STIG - Version 1, Release 8

### DIFF
--- a/ansible/group_vars/centos6
+++ b/ansible/group_vars/centos6
@@ -20,7 +20,9 @@ rhel6stig_cat2: true
 rhel6stig_cat3: true
 rhel6stig_fullauto: true
 rhel6stig_use_dhcp: false
-stig_benchmark: 'U_RedHat_6_V1R6_STIG_SCAP_1-1_Benchmark.zip'
+stig_benchmark: 'U_RedHat_6_V1R8_STIG_SCAP_1-1_Benchmark.zip'
+stig_baseurl: 'http://iasecontent.disa.mil/stigs/zip/July2015'
+
 java_benchmark: 'u_jre7_v1r5_stig.zip'
 apache_benchmark: 'U_Apache_2-2_UNIX_V1R6_STIG.zip'
 

--- a/ansible/security_audit.yml
+++ b/ansible/security_audit.yml
@@ -30,20 +30,22 @@
   - name: 'ensure absense of STIG_SCAP rhel-stig-report.html file'
     file: dest=/root/rhel-stig-report.html state=absent
 
-  - name: 'download from http://iase.disa.mil/stigs/Documents'
-    get_url: url=http://iase.disa.mil/stigs/Documents/{{stig_benchmark}}
-             dest=/tmp/{{stig_benchmark}}
+  - name: 'download from http://iase.disa.mil/'
+    get_url: url={{stig_baseurl}}/{{stig_benchmark}} dest=/tmp/{{stig_benchmark}}
 
   - name: 'unzip Security Content Automation Protocol (SCAP) Content and Tools'
     command: unzip -o /tmp/{{stig_benchmark}}
 
+  - name: 'make this benchmark work for Centos instead of RHEL'
+    shell: "perl -pi -e 's/redhat:enterprise_linux/centos:centos/;' *"
+
   - name: 'run the SCAP tool and create rhel-stig-report.html'
     command: "oscap xccdf eval \
-      --profile MAC-3_Classified \
+      --profile MAC-1_Sensitive \
       --results /root/results.xml \
       --report /root/rhel-stig-report.html \
-      --cpe U_RedHat_6_V1R6_STIG_SCAP_1-1_Benchmark-cpe-dictionary.xml \
-      U_RedHat_6_V1R6_STIG_SCAP_1-1_Benchmark-xccdf.xml"
+      --cpe U_RedHat_6_V1R8_STIG_SCAP_1-1_Benchmark-cpe-dictionary.xml \
+      U_RedHat_6_V1R8_STIG_SCAP_1-1_Benchmark-xccdf.xml"
     no_log: yes
     ignore_errors: yes
 


### PR DESCRIPTION
DISA release version 1 release 8 of the STIG and this is more strict. This PR allows running the oscap benchmark on Centos by replacing 3 strings.

Credit to: https://www.centos.org/forums/viewtopic.php?f=51&t=50462